### PR TITLE
Background fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 *.blg
 *.bbl
 *.synctex.gz
+*.fdb_latexmk
+*.out
+*.pdf
+*.toc

--- a/lib/book/rpg-backgroundimg.sty
+++ b/lib/book/rpg-backgroundimg.sty
@@ -37,10 +37,10 @@
 	angle=0,
 	color=black,
   contents={%
-  \ifodd\value{page}
+		\ifodd\value{page}
 			% implicit height is not supported on linux.
 			\includegraphics[width=\paperwidth,height=\paperheight]{\oddbackgroundimg}
-    \else
+		\else
 			% implicit height is not supported on linux.
 			\includegraphics[width=\paperwidth,height=\paperheight]{\evenbackgroundimg}
 		\fi

--- a/lib/book/rpg-backgroundimg.sty
+++ b/lib/book/rpg-backgroundimg.sty
@@ -37,9 +37,11 @@
 	angle=0,
 	color=black,
 	contents={%
-		\ifodd\value{page}
+    \ifodd\value{page}
+      % implicit height is not supported on linux.
 			\includegraphics[width=\paperwidth,height=\paperheight]{\oddbackgroundimg}
-			\else
+    \else
+      % implicit height is not supported on linux.
 			\includegraphics[width=\paperwidth,height=\paperheight]{\evenbackgroundimg}
 		\fi
 		}

--- a/lib/book/rpg-backgroundimg.sty
+++ b/lib/book/rpg-backgroundimg.sty
@@ -36,7 +36,7 @@
 	opacity=1.0,
 	angle=0,
 	color=black,
-  contents={%
+	contents={%
 		\ifodd\value{page}
 			% implicit height is not supported on linux.
 			\includegraphics[width=\paperwidth,height=\paperheight]{\oddbackgroundimg}

--- a/lib/book/rpg-backgroundimg.sty
+++ b/lib/book/rpg-backgroundimg.sty
@@ -36,12 +36,12 @@
 	opacity=1.0,
 	angle=0,
 	color=black,
-	contents={%
-    \ifodd\value{page}
-      % implicit height is not supported on linux.
+  contents={%
+  \ifodd\value{page}
+			% implicit height is not supported on linux.
 			\includegraphics[width=\paperwidth,height=\paperheight]{\oddbackgroundimg}
     \else
-      % implicit height is not supported on linux.
+			% implicit height is not supported on linux.
 			\includegraphics[width=\paperwidth,height=\paperheight]{\evenbackgroundimg}
 		\fi
 		}

--- a/lib/book/rpg-backgroundimg.sty
+++ b/lib/book/rpg-backgroundimg.sty
@@ -38,9 +38,9 @@
 	color=black,
 	contents={%
 		\ifodd\value{page}
-			\includegraphics[width=\paperwidth]{\oddbackgroundimg}
+			\includegraphics[width=\paperwidth,height=\paperheight]{\oddbackgroundimg}
 			\else
-			\includegraphics[width=\paperwidth]{\evenbackgroundimg}
+			\includegraphics[width=\paperwidth,height=\paperheight]{\evenbackgroundimg}
 		\fi
 		}
 	}


### PR DESCRIPTION
Hi guys,

Nice template !

I fixed the background of the book template because implicit height doesn't work on linux. As you can imagine, it's easier for me to add the height than to fix the implicit height in LaTeX.

Fell free to reject this pull request if you think this fix should go in LaTeX.

As you can see, I had a bit of trouble putting the tabs back. My editor was replacing them even when I copy-pasted a tab. Replacing tabs by spaces is a good practice that prevent the code indentation to be messed up when checking out on another PC. Just a suggestion. :smile: 

best regards,
Patrick